### PR TITLE
Backport some winegcc changes for dxvk

### DIFF
--- a/tools/winegcc/utils.c
+++ b/tools/winegcc/utils.c
@@ -230,6 +230,7 @@ file_type get_file_type(const char* filename)
 
     if (cnt == sizeof(res_sig) && !memcmp(buf, res_sig, sizeof(res_sig))) return file_res;
     if (strendswith(filename, ".o")) return file_obj;
+    if (strendswith(filename, ".obj")) return file_obj;
     if (strendswith(filename, ".a")) return file_arh;
     if (strendswith(filename, ".res")) return file_res;
     if (strendswith(filename, ".so")) return file_so;

--- a/tools/winegcc/winegcc.c
+++ b/tools/winegcc/winegcc.c
@@ -1920,6 +1920,13 @@ int main(int argc, char **argv)
 		    opts.output_name = option_arg;
                     raw_compiler_arg = 0;
 		    break;
+                case 'p':
+                    if (strcmp("-pthread", opts.args->base[i]) == 0)
+                    {
+                        raw_compiler_arg = 1;
+                        raw_linker_arg = 1;
+                    }
+                    break;
                 case 's':
                     if (strcmp("-static", opts.args->base[i]) == 0)
 			linking = -1;

--- a/tools/winegcc/winegcc.c
+++ b/tools/winegcc/winegcc.c
@@ -2011,7 +2011,7 @@ int main(int argc, char **argv)
                                 opts.debug_file = strdup( Wl->base[++j] );
                                 continue;
                             }
-                            if (!strcmp(Wl->base[j], "--whole-archive") || !strcmp(Wl->base[j], "--no-whole-archive"))
+                            if (!strcmp(Wl->base[j], "--whole-archive") || !strcmp(Wl->base[j], "--no-whole-archive") || !strcmp(Wl->base[j], "--start-group") || !strcmp(Wl->base[j], "--end-group"))
                             {
                                 strarray_add( opts.files, strmake( "-Wl,%s", Wl->base[j] ));
                                 continue;

--- a/tools/winegcc/winegcc.c
+++ b/tools/winegcc/winegcc.c
@@ -1963,7 +1963,7 @@ int main(int argc, char **argv)
                     if (strncmp("-Wl,", opts.args->base[i], 4) == 0)
 		    {
                         unsigned int j;
-                        strarray* Wl = strarray_fromstring(opts.args->base[i] + 4, ",");
+                        strarray* Wl = strarray_fromstring(opts.args->base[i] + 4, ",=");
                         for (j = 0; j < Wl->size; j++)
                         {
                             if (!strcmp(Wl->base[j], "--image-base") && j < Wl->size - 1)


### PR DESCRIPTION
I recently cleaned up and upstreamed my winegcc patches for building dxvk. By backporting them I can use the same winegcc toolchain used to compile the rest of wine-host to compile my dxvk fork. These landed in Wine 6.12.