### PR TITLE
port: Don't define dlopen etc. when dlfcn.h is available

### DIFF
--- a/include/wine/port.h
+++ b/include/wine/port.h
@@ -55,11 +55,6 @@
 
 #define mkdir(path,mode) mkdir(path)
 
-static inline void *dlopen(const char *name, int flags) { return NULL; }
-static inline void *dlsym(void *handle, const char *name) { return NULL; }
-static inline int dlclose(void *handle) { return 0; }
-static inline const char *dlerror(void) { return "No dlopen support on Windows"; }
-
 #ifdef _MSC_VER
 
 #define popen _popen
@@ -111,12 +106,21 @@ extern int _spawnvp(int mode, const char *cmdname, const char * const argv[]);
  */
 
 #ifdef HAVE_DLFCN_H
+
 #include <dlfcn.h>
+
 #else
+
+static inline void *dlopen(const char *name, int flags) { return NULL; }
+static inline void *dlsym(void *handle, const char *name) { return NULL; }
+static inline int dlclose(void *handle) { return 0; }
+static inline const char *dlerror(void) { return "No dlopen support on Windows"; }
+
 #define RTLD_LAZY    0x001
 #define RTLD_NOW     0x002
 #define RTLD_GLOBAL  0x100
-#endif
+
+#endif  /* HAVE_DLFCN_H */
 
 #ifndef S_ISLNK
 # define S_ISLNK(mod) (0)


### PR DESCRIPTION
Otherwise I get the following build error:

```
In file included from ../../wine/include/wine/port.h:114,
                 from ../../wine/libs/port/getopt.c:31:
/usr/x86_64-w64-mingw32/sys-root/mingw/include/dlfcn.h:53:20: error: conflicting types for 'dlerror'
   53 | DLFCN_EXPORT char *dlerror(void);
      |                    ^~~~~~~
In file included from ../../wine/libs/port/getopt.c:31:
../../wine/include/wine/port.h:61:27: note: previous definition of 'dlerror' was here
   61 | static inline const char *dlerror(void) { return "No dlopen support on Windows"; }
      |                           ^~~~~~~
make[2]: *** [Makefile:196739: libs/port/getopt.o] Error 1
```

This seems to be because building the guest wine on aarch64 uses mingw as the "host"
compiler and this library is built with the host toolchain.