### PR TITLE
fexcore: fix -Wincompatible-function-pointer-types from void to NSTATUS

### DIFF
--- a/dlls/fexcore/unixlib.c
+++ b/dlls/fexcore/unixlib.c
@@ -101,7 +101,7 @@ static NTSTATUS emu_run( void *args )
     return 0;
 }
 
-static void invalidate_code_range ( void *args )
+static NSTATUS invalidate_code_range ( void *args )
 {
     const struct invalidate_code_range_params *params = args;
     phangover_fex_invalidate_code_range(params->base, params->length);


### PR DESCRIPTION
__wine_unix_call_funcs[] expects elements of signature `typedef NTSTATUS (*unixlib_entry_t)( void *args )`